### PR TITLE
fixed issue related to modswitch and raw type

### DIFF
--- a/eva/ckks/mod_switcher.h
+++ b/eva/ckks/mod_switcher.h
@@ -53,6 +53,10 @@ public:
   void operator()(
       Term::Ptr &term) { // must only be used with backward pass traversal
     if (term->numUses() == 0) return;
+
+    //we do not want to add modswitch for nodes of type raw
+    if (type[term] == Type::Raw) return;
+
     if (term->op == Op::Encode) {
       encodeNodes.push_back(term);
     }


### PR DESCRIPTION
There was an issue when a raw type node is used at multiple levels. Modswitch nodes are added for raw type node if it is used at multiple nodes. However, Modswitch doesn't make sense for Raw type of data, and it is not supported by the backend. To fix this issue, I have modified the Modswitch pass to avoid nodes of Raw type. 