### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+# Install dependencies
+# DEBIAN_FRONTEND=noninteractive necessary for tzdata dependency package
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  clang \
+  cmake \
+  libboost-all-dev \
+  libprotobuf-dev \
+  protobuf-compiler \
+  git \
+  pip
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 && \
+  update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+
+# Install SEAL
+WORKDIR /home/root
+RUN git clone -b v3.6.4 https://github.com/microsoft/SEAL.git && \
+  cd SEAL && \
+  cmake -DSEAL_THROW_ON_TRANSPARENT_CIPHERTEXT=OFF . && \
+  make -j && \
+  make install
+
+# Install EVA
+WORKDIR /home/root
+RUN git clone -b v1.0.1 https://github.com/microsoft/EVA && \
+  cd EVA && \
+  git submodule update --init && \
+  cmake . && \
+  make -j && \
+  python3 -m pip install -e python && \
+  python3 python/setup.py bdist_wheel --dist-dir='.' && \
+  python3 -m pip install numpy && \
+  python3 tests/all.py

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ EVA targets [Microsoft SEAL](https://github.com/microsoft/SEAL) — the industry
 
 EVA is a native library written in C++17 with bindings for Python. Both Linux and Windows are supported. The instructions below show how to get started with EVA on Ubuntu. For building on Windows [EVA's Azure Pipelines script](azure-pipelines.yml) is a useful reference.
 
+You can also build a Docker image with EVA and SEAL installed. This is useful if you want to run EVA on unsupported platforms (e.g. macOS). See [Getting Started with Docker](#getting-started-with-docker) below.
+
 ### Installing Dependencies
 
 To install dependencies on Ubuntu 20.04:
@@ -67,6 +69,24 @@ python3 image_processing.py
 ```
 This will compile and run homomorphic evaluations of a Sobel edge detection filter and a Harris corner detection filter on `examples/baboon.png`, producing results of homomorphic evaluation in `*_encrypted.png` and reference results from normal execution in `*_reference.png`.
 The script also reports the mean squared error between these for each filter.
+
+## Getting Started with Docker
+
+Build the Docker image:
+
+```bash
+docker build -t eva:v1.0.1 .
+```
+
+Run the Docker image:
+
+```bash
+docker run -ti eva:v1.0.1
+```
+
+This will drop you into the running Docker container where you will find a working installation of SEAL and EVA.
+
+> For installing Docker, follow the instructions [here](https://docs.docker.com/get-docker/).
 
 ## Programming with PyEVA
 


### PR DESCRIPTION
I added a Dockerfile for creating a Docker image with SEAL and EVA installed. Also added instructions for how to use it to the README.

This is useful for using EVA on unsupported platforms (e.g. macOS) or when encountering difficulties when trying to install it natively.